### PR TITLE
unset force_ruby_platform before bundle install

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -24,6 +24,7 @@ variables:
     - export LANG=C.UTF-8
     - export LC_ALL=C.UTF-8
     - gem install bundler -v ${BUNDLER_VERSION:-2.2.28}
+    - bundle config set --local force_ruby_platform false
     - bundle config set path 'vendor'
     - bundle install # Ensure Gem installed
   cache:


### PR DESCRIPTION
ref: https://github.com/rails/tailwindcss-rails#check-bundle_force_ruby_platform

For current newest bundler & ruby version, we must unset force_ruby_platform before bundle install to make Tailwindcss standalone command work.