### PR TITLE
unset force_ruby_platform before bundle install

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -26,6 +26,7 @@ variables:
     - export LC_ALL=C.UTF-8
     - echo -e "\e[0Ksection_start:`date +%s`:bundle_install[collapsed=true]\r\e[0KBundle Install"
     - gem install bundler -v ${BUNDLER_VERSION:-2.3.20}
+    - bundle config set --local force_ruby_platform false
     - bundle config set path 'vendor'
     - bundle install # Ensure Gem installed
     - echo -e "\e[0Ksection_end:`date +%s`:bundle_install\r\e[0K"


### PR DESCRIPTION
ref: https://github.com/rails/tailwindcss-rails#check-bundle_force_ruby_platform

For current newest bundler & ruby version, we must unset force_ruby_platform before bundle install to make Tailwindcss standalone command work.