### PR TITLE
Update to new clear cache command

### DIFF
--- a/docker.yml
+++ b/docker.yml
@@ -88,7 +88,7 @@ trivy:
   script:
     - trivy --version
     # cache cleanup is needed when scanning images with the same tags, it does not remove the database
-    - time trivy image --clear-cache
+    - time trivy clean --scan-cache
     # update vulnerabilities db
     - time trivy image --download-db-only
     # Builds report and puts it in the default workdir $CI_PROJECT_DIR, so `artifacts:` can take it from there


### PR DESCRIPTION
- 更新清除快取的指令，因 v0.53 開始不支援舊的指令
- 可以參考這個 [discussion](https://github.com/aquasecurity/trivy/discussions/7010l)