### PR TITLE
Add RUBY_PLATFORM variable to able to support JRUBY

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The options are usually based on the `rules` keyword to enable the task. If you 
 
 | Type       | Environment Name        | Default   | Description                                                                                                       |
 |------------|-------------------------|-----------|-------------------------------------------------------------------------------------------------------------------|
+| Ruby       | `RUBY_PLATFORM`         | `ruby`    | The ruby plarform, available values: ruby, jruby                                                                  |
+
 | Ruby       | `RUBY_VERSION`          | `3.2.2`   | The ruby image version                                                                                            |
 | Ruby       | `SORBET_ENABLED`        | Unset     | Enable Sorbet gem to type check                                                                                   |
 | Ruby       | `RSPEC_JUNIT_REPORT`    | Unset     | Export JUnit report for GitLab CI with [RSpec JUnit Formatter](https://github.com/sj26/rspec_junit_formatter) gem |
@@ -133,6 +135,7 @@ The [GitOps](https://about.gitlab.com/topics/gitops/) allow us to management dep
 
 ## Roadmap
 
+* [x] JRuby Support
 * [x] Ruby support
   * [x] Rubocop
   * [x] RSpec

--- a/common.yml
+++ b/common.yml
@@ -20,7 +20,7 @@ variables:
   policy: pull
 
 .ruby:
-  image: ruby:$RUBY_VERSION
+  image: ${RUBY_PLATFORM}:$RUBY_VERSION
   before_script:
     - export LANG=C.UTF-8
     - export LC_ALL=C.UTF-8

--- a/ruby.yml
+++ b/ruby.yml
@@ -2,6 +2,7 @@ include:
   - remote: https://github.com/elct9620/ruby-gitlab-ci/raw/main/common.yml#ruby.yml
 
 variables:
+  RUBY_PLATFORM: ruby
   RUBY_VERSION: 3.2.2
   CUCUMBER_PUBLISH_QUIET: 'true'
 


### PR DESCRIPTION
This PR makes it possible to support JRuby by setting `RUBY_PLATFORM` variable.